### PR TITLE
fixes redirect issue; adds token query param; adds sign with secret key

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JupyterHub tokenauthenticator - A JWT Token Authenticator for JupyterHub
 
-Authenticate to Jupyterhub using an authenticating proxy that can set the Authorization header with the content of a JSONWebToken.
+Authenticate to Jupyterhub using a query parameter for the JSONWebToken, or by an authenticating proxy that can set the Authorization header with the content of a JSONWebToken.
 
 ## Installation
 
@@ -14,7 +14,7 @@ Alternately, you can add this project folder to your PYTHONPATH.
 
 ## Configuration
 
-You should edit your :file:`jupyterhub_config.py` to set the authenticator class, the JSONWebTokenLocalAuthenticator provides features such as local user creation. If you already have local users then you should use the JSONWebTokenAuthenticator authenticator class:
+You should edit your :file:`jupyterhub_config.py` to set the authenticator class, the JSONWebTokenLocalAuthenticator provides features such as local user creation. If you already have local users then you may use the JSONWebTokenAuthenticator authenticator class:
 
 ##### For authentication and local user creation
 ```
@@ -34,10 +34,14 @@ c.JupyterHub.authenticator_class = 'jwtauthenticator.jwtauthenticator.JSONWebTok
 You'll also need to set some configuration options including the location of the signing certificate (in PEM format), field containing the userPrincipalName or sAMAccountName/username, and the expected audience of the JSONWebToken. This last part is optional, if you set audience to an empty string then the authenticator will skip the validation of that field.
 
 ```
+# one of "secret" or "signing_certificate" must be given.  If both, then "secret" will be the signing method used.
+c.LocalAuthenticator.secret = '<insert-256-bit-secret-key-here>'            # The secrect key used to generate the given token
+# -OR-
 c.LocalAuthenticator.signing_certificate = '/foo/bar/adfs-signature.crt'    # The certificate used to sign the incoming JSONWebToken, must be in PEM Format
+
 c.LocalAuthenticator.username_claim_field = 'upn'                           # The claim field contianing the username/sAMAccountNAme/userPrincipalName
 c.LocalAuthenticator.audience = 'https://myApp.domain.local/'               # This config option should match the aud field of the JSONWebToken, empty string to disable the validation of this field.
-#c.LocalAuthenticator.create_system_users = True                            # This will enable local user creation upon authentication, requires JSONWebTokenLocalAuthenticator, see below.
+#c.LocalAuthenticator.create_system_users = True                            # This will enable local user creation upon authentication, requires JSONWebTokenLocalAuthenticator
 #c.LocalAuthenticator.header_name = 'Authorization'                         # default value
 ```
 

--- a/jwtauthenticator/jwtauthenticator.py
+++ b/jwtauthenticator/jwtauthenticator.py
@@ -22,6 +22,9 @@ class JSONWebTokenLoginHandler(BaseHandler):
         if auth_header_content and tokenParam:
            raise web.HTTPError(400)
         elif auth_header_content:
+           # we should not see "token" as first word in the AUTHORIZATION header, if we do it could mean someone coming in with a stale API token
+           if auth_header_content.split()[0] != "bearer":
+              raise web.HTTPError(403)
            token = auth_header_content.split()[1]
         elif tokenParam:
            token = tokenParam

--- a/jwtauthenticator/jwtauthenticator.py
+++ b/jwtauthenticator/jwtauthenticator.py
@@ -12,30 +12,51 @@ class JSONWebTokenLoginHandler(BaseHandler):
         header_name = self.authenticator.header_name
         auth_header_content = self.request.headers.get(header_name, "")
         signing_certificate = self.authenticator.signing_certificate
+        secret = self.authenticator.secret
         username_claim_field = self.authenticator.username_claim_field
         audience = self.authenticator.expected_audience
+        tokenParam = self.get_argument('token', default=False)
 
-        if auth_header_content == "":
-            raise web.HTTPError(401)
+        if tokenParam:
+           token = tokenParam
+        elif auth_header_content:
+           token = auth_header_content.split()[1]
         else:
-            # we should process the token here
-            claims = self.verify_jwt_with_claims(auth_header_content, signing_certificate, audience)
-            username = self.retrieve_username(claims, username_claim_field)
+           raise web.HTTPError(401)
 
-            user = self.user_from_username(username)
-            self.set_login_cookie(user)
-            self.redirect(url_path_join(self.hub.server.base_url, 'home'))
+        claims = "";
+        if secret:
+            claims = self.verify_jwt_using_secret(token,secret)
+        elif signing_certificate:
+            claims = self.verify_jwt_with_claims(token, signing_certificate, audience)
+        else:
+           raise web.HTTPError(401)
+
+        username = self.retrieve_username(claims, username_claim_field)
+        user = self.user_from_username(username)
+        self.set_login_cookie(user)
+
+        _url = url_path_join(self.hub.server.base_url, 'home')
+        next_url = self.get_argument('next', default=False)
+        if next_url:
+             _url = next_url
+
+        self.redirect(_url)
 
     @staticmethod
-    def verify_jwt_with_claims(auth_header_content, signing_certificate, audience):
-        json_web_token = auth_header_content.split()[1]
+    def verify_jwt_with_claims(token, signing_certificate, audience):
         # If no audience is supplied then assume we're not verifying the audience field.
         if audience == "":
             opts = {"verify_aud": False}
         else:
             opts = {}
         with open(signing_certificate, 'r') as rsa_public_key_file:
-            return jwt.decode(json_web_token, rsa_public_key_file.read(), audience=audience, options=opts)
+            return jwt.decode(token, rsa_public_key_file.read(), audience=audience, options=opts)
+
+    @staticmethod
+    def verify_jwt_using_secret(json_web_token, secret):
+        # If no audience is supplied then assume we're not verifying the audience field.
+        return jwt.decode(json_web_token, secret, algorithms=['HS256'])
 
     @staticmethod
     def retrieve_username(claims, username_claim_field):
@@ -48,8 +69,6 @@ class JSONWebTokenLoginHandler(BaseHandler):
         else:
             # assume not username and return the user
             return username
-
-
 
 
 class JSONWebTokenAuthenticator(Authenticator):
@@ -84,6 +103,10 @@ class JSONWebTokenAuthenticator(Authenticator):
         default_value='Authorization',
         config=True,
         help="""HTTP header to inspect for the authenticated JSON Web Token.""")
+
+    secret = Unicode(
+        config=True,
+        help="""Shared secret key for siging JWT token.  If defined, it overrides any setting for signing_certificate""")
 
     def get_handlers(self, app):
         return [
@@ -130,6 +153,9 @@ class JSONWebTokenLocalAuthenticator(LocalAuthenticator):
         config=True,
         help="""HTTP header to inspect for the authenticated JSON Web Token.""")
 
+    secret = Unicode(
+        config=True,
+        help="""Shared secret key for siging JWT token.  If defined, it overrides any setting for signing_certificate""")
 
     def get_handlers(self, app):
         return [

--- a/jwtauthenticator/jwtauthenticator.py
+++ b/jwtauthenticator/jwtauthenticator.py
@@ -10,17 +10,21 @@ class JSONWebTokenLoginHandler(BaseHandler):
 
     def get(self):
         header_name = self.authenticator.header_name
+        param_name = self.authenticator.param_name
+
         auth_header_content = self.request.headers.get(header_name, "")
         signing_certificate = self.authenticator.signing_certificate
         secret = self.authenticator.secret
         username_claim_field = self.authenticator.username_claim_field
         audience = self.authenticator.expected_audience
-        tokenParam = self.get_argument('token', default=False)
+        tokenParam = self.get_argument(param_name, default=False)
 
-        if tokenParam:
-           token = tokenParam
+        if auth_header_content and tokenParam:
+           raise web.HTTPError(400)
         elif auth_header_content:
            token = auth_header_content.split()[1]
+        elif tokenParam:
+           token = tokenParam
         else:
            raise web.HTTPError(401)
 
@@ -104,6 +108,11 @@ class JSONWebTokenAuthenticator(Authenticator):
         config=True,
         help="""HTTP header to inspect for the authenticated JSON Web Token.""")
 
+    param_name = Unicode(
+        config=True,
+        default_value='access_token',
+        help="""The name of the query parameter used to specify the JWT token""")
+
     secret = Unicode(
         config=True,
         help="""Shared secret key for siging JWT token.  If defined, it overrides any setting for signing_certificate""")
@@ -152,6 +161,11 @@ class JSONWebTokenLocalAuthenticator(LocalAuthenticator):
         default_value='Authorization',
         config=True,
         help="""HTTP header to inspect for the authenticated JSON Web Token.""")
+
+    param_name = Unicode(
+        config=True,
+        default_value='access_token',
+        help="""The name of the query parameter used to specify the JWT token""")
 
     secret = Unicode(
         config=True,


### PR DESCRIPTION
This PR will address an issue with the JWT authenticator where it always redirects to "/home" after successful login.  Following the pattern of other authenticators, the authenticator should redirect to the value of the "next" query parameter if present.

The code goes on to add support for a secret key as signing method if present, and if not attempts to use the signing certificate.  Further, it adds another method of providing the token via query parameter of 'token'.