### PR TITLE
Use a mixin for LocalAuthenticator variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,14 @@ You'll also need to set some configuration options including the location of the
 
 ```
 # one of "secret" or "signing_certificate" must be given.  If both, then "secret" will be the signing method used.
-c.LocalAuthenticator.secret = '<insert-256-bit-secret-key-here>'            # The secrect key used to generate the given token
+c.JSONWebTokenAuthenticator.secret = '<insert-256-bit-secret-key-here>'            # The secrect key used to generate the given token
 # -OR-
-c.LocalAuthenticator.signing_certificate = '/foo/bar/adfs-signature.crt'    # The certificate used to sign the incoming JSONWebToken, must be in PEM Format
+c.JSONWebTokenAuthenticator.signing_certificate = '/foo/bar/adfs-signature.crt'    # The certificate used to sign the incoming JSONWebToken, must be in PEM Format
 
-c.LocalAuthenticator.username_claim_field = 'upn'                           # The claim field contianing the username/sAMAccountNAme/userPrincipalName
-c.LocalAuthenticator.audience = 'https://myApp.domain.local/'               # This config option should match the aud field of the JSONWebToken, empty string to disable the validation of this field.
-#c.LocalAuthenticator.create_system_users = True                            # This will enable local user creation upon authentication, requires JSONWebTokenLocalAuthenticator
-#c.LocalAuthenticator.header_name = 'Authorization'                         # default value
+c.JSONWebTokenAuthenticator.username_claim_field = 'upn'                           # The claim field contianing the username/sAMAccountNAme/userPrincipalName
+c.JSONWebTokenAuthenticator.audience = 'https://myApp.domain.local/'               # This config option should match the aud field of the JSONWebToken, empty string to disable the validation of this field.
+#c.JSONWebLocalTokenAuthenticator.create_system_users = True                       # This will enable local user creation upon authentication, requires JSONWebTokenLocalAuthenticator
+#c.JSONWebTokenAuthenticator.header_name = 'Authorization'                         # default value
 ```
 
 You should be able to start jupyterhub. :)

--- a/jwtauthenticator/jwtauthenticator.py
+++ b/jwtauthenticator/jwtauthenticator.py
@@ -130,55 +130,8 @@ class JSONWebTokenAuthenticator(Authenticator):
         raise NotImplementedError()
 
 
-class JSONWebTokenLocalAuthenticator(LocalAuthenticator):
+class JSONWebTokenLocalAuthenticator(JSONWebTokenAuthenticator, LocalAuthenticator):
     """
-    Accept the authenticated user name from the REMOTE_USER HTTP header.
-    Derived from LocalAuthenticator for use of features such as adding
-    local accounts through the admin interface.
+    A version of JSONWebTokenAuthenticator that mixes in local system user creation
     """
-    signing_certificate = Unicode(
-        config=True,
-        help="""
-        The public certificate of the private key used to sign the incoming JSON Web Tokens.
-
-        Should be a path to an X509 PEM format certificate filesystem.
-        """
-    )
-
-    username_claim_field = Unicode(
-        default_value='upn',
-        config=True,
-        help="""
-        The field in the claims that contains the user name. It can be either a straight username,
-        of an email/userPrincipalName.
-        """
-    )
-
-    expected_audience = Unicode(
-        default_value='',
-        config=True,
-        help="""HTTP header to inspect for the authenticated JSON Web Token."""
-    )
-
-    header_name = Unicode(
-        default_value='Authorization',
-        config=True,
-        help="""HTTP header to inspect for the authenticated JSON Web Token.""")
-
-    param_name = Unicode(
-        config=True,
-        default_value='access_token',
-        help="""The name of the query parameter used to specify the JWT token""")
-
-    secret = Unicode(
-        config=True,
-        help="""Shared secret key for siging JWT token.  If defined, it overrides any setting for signing_certificate""")
-
-    def get_handlers(self, app):
-        return [
-            (r'/login', JSONWebTokenLoginHandler),
-        ]
-
-    @gen.coroutine
-    def authenticate(self, *args):
-        raise NotImplementedError()
+    pass


### PR DESCRIPTION
- This uses the same pattern as in various OAuthenticators,
   for example https://github.com/jupyterhub/oauthenticator/blob/master/oauthenticator/github.py#L180
- Also cleanup README to point to more specific class names

Fixes #7 