### PR TITLE
Update README to point to installation from PyPi

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,15 @@ Authenticate to Jupyterhub using a query parameter for the JSONWebToken, or by a
 This package can be installed with pip:
 
 ```
-cd jwtauthenticator pip install .
+pip install jupyterhub-jwtauthenticator
 ```
 
-Alternately, you can add this project folder to your PYTHONPATH.
+Alternately, you can clone this repository and run:
+
+```
+cd jwtauthenticator
+pip install -e .
+```
 
 ## Configuration
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='jupyterhub-jwtauthenticator',
-    version='0.1',
+    version='0.2-dev',
     description='JSONWebToken Authenticator for JupyterHub',
     url='https://github.com/mogthesprog/jwtauthenticator',
     author='mogthesprog',


### PR DESCRIPTION
I made a release of current master to PyPI as jupyterhub-jwtauthenticator.
Am happy to give you owner rights on it - lmk your PyPI username! 
I hope that was ok and I am not overstepping my bounds :)

I also bumped current master version to v0.2-dev.